### PR TITLE
implement remove-by-model-name. Make backups of configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Documentation goes here...
 
 This wasn't designed to be shared, so you'll have to pretend I did a good job of documenting it. ;)
 
-Invoke it with the name of the entity you want to remove.
+Invoke it with the name or model of the entity you want to remove.
 
 WARNING: this works directly in your .storage directory. That should make you uncomfortable, so make sure to try it on a backup first.
+
+In an effort to be slighlty user-friendly, it will make backups of the existing config files before overwriting them, named \*.bak 
+
+You have one chance to put them back if HA looks wonky.


### PR DESCRIPTION
I had several hundred iBeacon devices to get rid of, all with long hex-string names, so I extended your code to do model names as well. Minimal change w/o restructuring completely. In the spirit of it being a power-user tool, but even power users can sometimes shoot themselves in the foot, I provided one level of toe-armor: it makes a backup of the three config files.